### PR TITLE
adding adjustedTime to index.js so that it can be referenced correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@carnegie-learning/caliper-ts",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"description": "Reference implementation of the Caliper Sensor API written in TypeScript",
 	"author": "Imagine Learning",
 	"license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,10 @@ export {
 	CaliperTimestamp,
 	default as Caliper,
 	URN,
-} from './caliper';
-export * from './clients/httpClient';
-export { Config } from './config/config';
-export { Envelope, EnvelopeOptions } from './envelope';
-export * from './models';
-export * from './sensor';
+} from "./caliper";
+export * from "./clients/httpClient";
+export { Config } from "./config/config";
+export { Envelope, EnvelopeOptions } from "./envelope";
+export * from "./models";
+export * from "./sensor";
+export * from "./adjustedTime";


### PR DESCRIPTION
Adding AdjustedTime to index.js so that it can be referenced

I am hoping this will solve the dependency issues that I am seeing when I try to pull this into tutorstream, and may have fixed the issues we were seeing in cli-services with the tests.